### PR TITLE
split out scroll table so that div table add specific support for layout

### DIFF
--- a/example/controller/generated-router.ts
+++ b/example/controller/generated-router.ts
@@ -55,6 +55,12 @@ export let genRouter = {
     path: () => `/wide`,
     go: () => switchPath(`/wide`),
   },
+  tall: {
+    name: "tall",
+    raw: "tall",
+    path: () => `/tall`,
+    go: () => switchPath(`/tall`),
+  },
   _: {
     name: "home",
     raw: "",

--- a/example/models/router-rules.ts
+++ b/example/models/router-rules.ts
@@ -8,5 +8,6 @@ export const routerRules: IRouteRule[] = [
   { path: "whole-borders" },
   { path: "home" },
   { path: "wide" },
+  { path: "tall" },
   { path: "", name: "home" },
 ];

--- a/example/pages/container.tsx
+++ b/example/pages/container.tsx
@@ -16,6 +16,7 @@ import PageEmpty from "./pages/empty";
 import PageSelected from "./pages/selected";
 import PageWide from "./pages/wide";
 import PageBasic from "./pages/basic";
+import PageTall from "./pages/tall";
 
 const renderBody = (routerTree: IRouteParseResult) => {
   if (routerTree != null) {
@@ -32,6 +33,8 @@ const renderBody = (routerTree: IRouteParseResult) => {
         return <PageSelected />;
       case genRouter.wide.name:
         return <PageWide />;
+      case genRouter.tall.name:
+        return <PageTall />;
 
       case genRouter.home.name:
         return <Home />;
@@ -64,6 +67,10 @@ let entries: ISidebarEntry[] = [
   {
     title: "Wide",
     path: genRouter.wide.name,
+  },
+  {
+    title: "Tall",
+    path: genRouter.tall.name,
   },
 ];
 

--- a/example/pages/pages/tall.tsx
+++ b/example/pages/pages/tall.tsx
@@ -4,6 +4,7 @@ import { css, cx } from "emotion";
 import RoughDivTable from "../../../src/rough-div-table";
 import ActionLinks, { IActionLinkItem } from "../../../src/action-links";
 import { fullHeight } from "@jimengio/shared-utils";
+import ScrollDivTable from "../../../src/scroll-div-table";
 
 let data = [
   { code: "001", name: "螺丝", model: "DDR6", source: "外购", type: "产品" },
@@ -34,18 +35,33 @@ let actions: IActionLinkItem[] = [
 
 let PageTall: FC<{}> = (props) => {
   return (
-    <div className={styleContainer}>
-      <RoughDivTable
-        className={cx(fullHeight)}
-        data={data}
-        labels={["物料编号", "名称", "型号", "操作"]}
-        lastColumnWidth={80}
-        rowPadding={60}
-        renderColumns={(item) => {
-          return [item.code, item.name, item.model, <ActionLinks actions={actions} spaced />];
-        }}
-        pageOptions={{}}
-      />
+    <div>
+      <div className={styleContainer}>
+        <RoughDivTable
+          className={cx(fullHeight)}
+          data={data}
+          labels={["物料编号", "名称", "型号", "操作"]}
+          lastColumnWidth={80}
+          rowPadding={60}
+          renderColumns={(item) => {
+            return [item.code, item.name, item.model, <ActionLinks actions={actions} spaced />];
+          }}
+          pageOptions={{}}
+        />
+      </div>
+      <div className={styleContainer}>
+        <ScrollDivTable
+          className={cx(fullHeight)}
+          data={data}
+          labels={["物料编号", "名称", "型号", "操作"]}
+          lastColumnWidth={80}
+          rowPadding={60}
+          renderColumns={(item) => {
+            return [item.code, item.name, item.model, <ActionLinks actions={actions} spaced />];
+          }}
+          pageOptions={{}}
+        />
+      </div>
     </div>
   );
 };

--- a/example/pages/pages/tall.tsx
+++ b/example/pages/pages/tall.tsx
@@ -1,0 +1,57 @@
+import React, { FC } from "react";
+import { css, cx } from "emotion";
+
+import RoughDivTable from "../../../src/rough-div-table";
+import ActionLinks, { IActionLinkItem } from "../../../src/action-links";
+import { fullHeight } from "@jimengio/shared-utils";
+
+let data = [
+  { code: "001", name: "螺丝", model: "DDR6", source: "外购", type: "产品" },
+  { code: "003", name: "扳手", model: "DDR6", source: "外购", type: "产品" },
+  { code: "004", name: "堵头", model: "33-36", source: "外购", type: "产品" },
+  { code: "044", name: "软管", model: "HO", source: "外购", type: "产品" },
+  { code: "045", name: 0, model: "HO", source: "外购", type: "产品" },
+];
+
+data = data.concat(data, data, data, data, data, data, data, data, data, data, data);
+
+let actions: IActionLinkItem[] = [
+  {
+    text: "修改",
+    onClick: () => {},
+  },
+  {
+    text: "删除",
+    onClick: () => {},
+  },
+  {
+    hidden: true,
+    text: "恢复",
+    onClick: () => {},
+  },
+  null,
+];
+
+let PageTall: FC<{}> = (props) => {
+  return (
+    <div className={styleContainer}>
+      <RoughDivTable
+        className={cx(fullHeight)}
+        data={data}
+        labels={["物料编号", "名称", "型号", "操作"]}
+        lastColumnWidth={80}
+        rowPadding={60}
+        renderColumns={(item) => {
+          return [item.code, item.name, item.model, <ActionLinks actions={actions} spaced />];
+        }}
+        pageOptions={{}}
+      />
+    </div>
+  );
+};
+
+export default PageTall;
+
+let styleContainer = css`
+  height: 600px;
+`;

--- a/example/pages/pages/wide.tsx
+++ b/example/pages/pages/wide.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import { css } from "emotion";
 
-import RoughDivTable from "../../../src/rough-div-table";
+import ScrollDivTable from "../../../src/scroll-div-table";
 
 let countMany = Array.from({ length: 100 }, (_, n) => n);
 
@@ -15,7 +15,7 @@ let data = [
 let PageWide: FC<{}> = (props) => {
   return (
     <div className={styleContainer}>
-      <RoughDivTable
+      <ScrollDivTable
         data={data}
         labels={countMany}
         lastColumnWidth={80}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/rough-table",
-  "version": "0.1.8-a1",
+  "version": "0.1.8-a2",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/rough-table",
-  "version": "0.1.8-a2",
+  "version": "0.1.8-a4",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { default as RoughTable } from "./rough-table";
 export { default as RoughDivTable } from "./rough-div-table";
+export { default as ScrollDivTable } from "./scroll-div-table";
 
 export { default as Space } from "./space";
 

--- a/src/scroll-div-table.tsx
+++ b/src/scroll-div-table.tsx
@@ -102,7 +102,7 @@ export default class ScrollDivTable extends React.Component<IProps, IState> {
 
     return (
       <div className={cx(flex, column, styleContainer, this.props.wholeBorders ? styleWholeBorders : null, this.props.className)}>
-        <div className={styleContentWrapper}>
+        <div className={cx(flex, column)}>
           <div className={styleContentArea}>
             {headElement}
             <div className={styleBody}>{bodyElement}</div>
@@ -208,10 +208,6 @@ let stylePageArea = css`
 let styleEmptyIcon = css`
   font-size: 80px;
   margin-bottom: 8px;
-`;
-
-let styleContentWrapper = css`
-  overflow: auto;
 `;
 
 /** requires Chrome 46 */

--- a/src/scroll-div-table.tsx
+++ b/src/scroll-div-table.tsx
@@ -1,10 +1,10 @@
-/** DivTable layouts with Flexbox
- * to render data with plenty of columns, use ScrollTable
+/** Table which supports horizontal scrolling.
+ * code splitted from DivTable
  */
 
 import React, { ReactNode } from "react";
 import { css, cx } from "emotion";
-import { center, column, flex, rowParted, row, expand } from "@jimengio/shared-utils";
+import { center, column, flex, rowParted, row } from "@jimengio/shared-utils";
 import { Pagination } from "antd";
 import JimoIcon, { EJimoIcon } from "@jimengio/jimo-icons";
 import { PaginationProps } from "antd/lib/pagination";
@@ -34,7 +34,7 @@ interface IProps {
 
 interface IState {}
 
-export default class RoughDivTable extends React.Component<IProps, IState> {
+export default class ScrollDivTable extends React.Component<IProps, IState> {
   render() {
     const { selectedKeys, rowPadding = 80, columnWidths = [], showEmptySymbol, rowKey = "id", labels } = this.props;
 
@@ -102,8 +102,12 @@ export default class RoughDivTable extends React.Component<IProps, IState> {
 
     return (
       <div className={cx(flex, column, styleContainer, this.props.wholeBorders ? styleWholeBorders : null, this.props.className)}>
-        {headElement}
-        <div className={cx(expand, styleBody)}>{bodyElement}</div>
+        <div className={styleContentWrapper}>
+          <div className={styleContentArea}>
+            {headElement}
+            <div className={styleBody}>{bodyElement}</div>
+          </div>
+        </div>
         {this.props.pageOptions != null ? this.renderPagination() : null}
       </div>
     );
@@ -204,6 +208,10 @@ let stylePageArea = css`
 let styleEmptyIcon = css`
   font-size: 80px;
   margin-bottom: 8px;
+`;
+
+let styleContentWrapper = css`
+  overflow: auto;
 `;
 
 /** requires Chrome 46 */


### PR DESCRIPTION
两个组件拆分开了, ScrollTableForm 需要支持横向滚动, 后续需要专门优化. DivTable 可以保持一个比较简单的 DOM 结构. 调整了一下 ScrollTable 以便适应 flexbox 布局当中稳定分页器.