### PR TITLE
Change layout algorithm of ScrollDivTable

### DIFF
--- a/example/main.css
+++ b/example/main.css
@@ -1,0 +1,19 @@
+body * {
+  box-sizing: border-box;
+}
+
+::-webkit-scrollbar {
+  width: 7px;
+  height: 7px;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: #a6a6a6;
+  border-left: 2px solid transparent;
+  cursor: pointer;
+}
+
+::-webkit-scrollbar-track {
+  background-color: #e5e5e5;
+  border-left: 2px solid transparent;
+}

--- a/example/main.tsx
+++ b/example/main.tsx
@@ -1,3 +1,5 @@
+import "./main.css";
+
 import ReactDOM, { unstable_renderSubtreeIntoContainer } from "react-dom";
 import React from "react";
 

--- a/example/pages/pages/tall.tsx
+++ b/example/pages/pages/tall.tsx
@@ -45,10 +45,6 @@ let PageTall: FC<{}> = (props) => {
       <div className={styleContainer}>
         <RoughDivTable className={cx(fullHeight)} data={data} columns={columns} rowPadding={60} pageOptions={{}} />
       </div>
-      <div>body 部分上下左右滚动(目前头部也发生滚动)</div>
-      <div className={styleContainer}>
-        <ScrollDivTable className={cx(fullHeight)} data={data} columns={columns} rowPadding={60} pageOptions={{}} />
-      </div>
     </div>
   );
 };

--- a/example/pages/pages/wide.tsx
+++ b/example/pages/pages/wide.tsx
@@ -1,8 +1,9 @@
 import React, { FC } from "react";
-import { css } from "emotion";
+import { css, cx } from "emotion";
 
 import ScrollDivTable from "../../../src/scroll-div-table";
 import { IRoughTableColumn } from "../../../src/rough-div-table";
+import { fullHeight } from "@jimengio/shared-utils";
 
 let countMany = Array.from({ length: 100 }, (_, n) => n);
 
@@ -21,6 +22,25 @@ let data = [
   { code: "044", name: "软管", model: "HO", source: "外购", type: "产品" },
 ];
 
+let data2 = [
+  { code: "001", name: "螺丝", model: "DDR6", source: "外购", type: "产品" },
+  { code: "003", name: "扳手", model: "DDR6", source: "外购", type: "产品" },
+  { code: "004", name: "堵头", model: "33-36", source: "外购", type: "产品" },
+  { code: "045", name: "软管", model: "HO", source: "外购", type: "产品" },
+  { code: "046", name: "软管", model: "HO", source: "外购", type: "产品" },
+  { code: "047", name: "软管", model: "HO", source: "外购", type: "产品" },
+  { code: "048", name: "软管", model: "HO", source: "外购", type: "产品" },
+  { code: "049", name: "软管", model: "HO", source: "外购", type: "产品" },
+  { code: "050", name: "软管", model: "HO", source: "外购", type: "产品" },
+  { code: "051", name: "软管", model: "HO", source: "外购", type: "产品" },
+  { code: "052", name: "软管", model: "HO", source: "外购", type: "产品" },
+  { code: "053", name: "软管", model: "HO", source: "外购", type: "产品" },
+  { code: "054", name: "软管", model: "HO", source: "外购", type: "产品" },
+  { code: "055", name: "软管", model: "HO", source: "外购", type: "产品" },
+  { code: "056", name: "软管", model: "HO", source: "外购", type: "产品" },
+  { code: "057", name: "软管", model: "HO", source: "外购", type: "产品" },
+];
+
 let columns: IRoughTableColumn<IData>[] = countMany.map((n) => {
   return {
     title: n,
@@ -33,6 +53,11 @@ let PageWide: FC<{}> = (props) => {
   return (
     <div className={styleContainer}>
       <ScrollDivTable data={data} columns={columns} rowPadding={60} pageOptions={{ current: 1, total: 100, pageSize: 10, onChange: (x) => {} }} />
+
+      <div>body 部分上下左右滚动(目前头部也发生滚动)</div>
+      <div className={styleRestricted}>
+        <ScrollDivTable className={cx(fullHeight)} data={data2} columns={columns} rowPadding={60} pageOptions={{}} />
+      </div>
     </div>
   );
 };
@@ -40,3 +65,7 @@ let PageWide: FC<{}> = (props) => {
 export default PageWide;
 
 let styleContainer = null;
+
+let styleRestricted = css`
+  height: 400px;
+`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/rough-table",
-  "version": "0.1.9-a1",
+  "version": "0.1.10-a1",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -22,7 +22,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@jimengio/doc-frame": "^0.1.0",
+    "@jimengio/doc-frame": "^0.1.1",
     "@jimengio/jimo-icons": "^0.1.19",
     "@jimengio/router-code-generator": "^0.1.5",
     "@jimengio/ruled-router": "^0.2.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/rough-table",
-  "version": "0.1.10-a1",
+  "version": "0.1.10-a2",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/scroll-div-table.tsx
+++ b/src/scroll-div-table.tsx
@@ -31,12 +31,15 @@ type ScrollDivTableProps<T = any> = FC<{
 }>;
 
 let ScrollDivTable: ScrollDivTableProps = (props) => {
+  const { selectedKeys, rowPadding = 80, showEmptySymbol, rowKey = "id" } = props;
+  let columns = props.columns.filter((col) => col != null && !col.hidden);
+
   let scrollRef = useRef<HTMLDivElement>();
   let headerRef = useRef<HTMLDivElement>();
 
   let defaultCellWidth = 120;
   let cellWidths: number[] = props.columns.map((columnConfig) => (columnConfig.width as number) || defaultCellWidth);
-  let allWidth = cellWidths.reduce((x, y) => x + y) + props.rowPadding * 2;
+  let allWidth = cellWidths.reduce((x, y) => x + y) + rowPadding * 2;
 
   /** Methods */
 
@@ -64,9 +67,6 @@ let ScrollDivTable: ScrollDivTableProps = (props) => {
       </div>
     );
   };
-
-  const { selectedKeys, rowPadding = 80, showEmptySymbol, rowKey = "id" } = props;
-  let columns = props.columns.filter((col) => col != null && !col.hidden);
 
   let hasData = props.data.length > 0;
 

--- a/src/scroll-div-table.tsx
+++ b/src/scroll-div-table.tsx
@@ -2,16 +2,16 @@
  * code splitted from DivTable
  */
 
-import React, { ReactNode, FC, CSSProperties } from "react";
+import React, { ReactNode, FC, CSSProperties, useRef } from "react";
 import { css, cx } from "emotion";
-import { center, column, flex, rowParted, row } from "@jimengio/shared-utils";
+import { center, column, flex, rowParted, row, expand } from "@jimengio/shared-utils";
 import { Pagination } from "antd";
 import { PaginationProps } from "antd/lib/pagination";
 import { IRoughTableColumn } from "./rough-div-table";
 import { ISimpleObject } from "./types";
-import NoDataTableBody, { mergeStyles, getWidthStyle, EmptyCell } from "./common";
+import NoDataTableBody, { mergeStyles, EmptyCell } from "./common";
 
-type ScrollDivTableProps<T = ISimpleObject> = FC<{
+type ScrollDivTableProps<T = any> = FC<{
   className?: string;
   data: T[];
   /** Displayed in headers */
@@ -28,13 +28,25 @@ type ScrollDivTableProps<T = ISimpleObject> = FC<{
   emptyLocale?: string;
   /** Display empty symbol rather than set it transparent */
   showEmptySymbol?: boolean;
-
-  wholeBorders?: boolean;
 }>;
 
 let ScrollDivTable: ScrollDivTableProps = (props) => {
+  let scrollRef = useRef<HTMLDivElement>();
+  let headerRef = useRef<HTMLDivElement>();
+
+  let defaultCellWidth = 120;
+  let cellWidths: number[] = props.columns.map((columnConfig) => (columnConfig.width as number) || defaultCellWidth);
+  let allWidth = cellWidths.reduce((x, y) => x + y) + props.rowPadding * 2;
+
   /** Methods */
+
+  let handleScroll = () => {
+    let leftOffset = scrollRef.current.scrollLeft;
+    headerRef.current.style.left = `${-leftOffset}px`;
+  };
+
   /** Effects */
+
   /** Renderers */
 
   let renderPagination = () => {
@@ -63,26 +75,22 @@ let ScrollDivTable: ScrollDivTableProps = (props) => {
     rowPaddingStyle = { paddingLeft: rowPadding, paddingRight: rowPadding };
   }
 
-  let headElement = (
-    <div className={cx(row, styleRow, styleHeaderBar)} style={rowPaddingStyle}>
-      {columns.map((columnConfig, idx) => {
-        return (
-          <div
-            key={idx}
-            className={cx(styleCell, props.cellClassName, columnConfig.className)}
-            style={mergeStyles(columnConfig.style, getWidthStyle(columnConfig.width))}
-          >
-            {columnConfig.title || <EmptyCell showSymbol />}
-          </div>
-        );
-      })}
-    </div>
-  );
+  let headElements = columns.map((columnConfig, idx) => {
+    return (
+      <div
+        key={idx}
+        className={cx(styleCell, props.cellClassName, columnConfig.className)}
+        style={mergeStyles(columnConfig.style, { width: columnConfig.width || defaultCellWidth })}
+      >
+        {columnConfig.title || <EmptyCell showSymbol />}
+      </div>
+    );
+  });
 
-  let bodyElement: ReactNode = <NoDataTableBody emptyLocale={props.emptyLocale} />;
+  let bodyElements: ReactNode = <NoDataTableBody emptyLocale={props.emptyLocale} />;
 
   if (hasData) {
-    bodyElement = props.data.map((record, idx) => {
+    bodyElements = props.data.map((record, idx) => {
       let rowClassName: string;
       if (selectedKeys != null && selectedKeys.includes(record[rowKey])) {
         rowClassName = styleSelectedRow;
@@ -91,8 +99,8 @@ let ScrollDivTable: ScrollDivTableProps = (props) => {
       return (
         <div
           key={idx}
-          className={cx(row, styleRow, props.onRowClick != null && styleCursorPointer, rowClassName)}
-          style={rowPaddingStyle}
+          className={cx(styleRow, props.onRowClick != null && styleCursorPointer, rowClassName)}
+          style={mergeStyles({ width: allWidth, minWidth: "100%" }, rowPaddingStyle)}
           onClick={props.onRowClick != null ? () => props.onRowClick(record) : null}
         >
           {props.columns.map((columnConfig, colIdx) => {
@@ -105,7 +113,7 @@ let ScrollDivTable: ScrollDivTableProps = (props) => {
               <div
                 key={colIdx}
                 className={cx(styleCell, props.cellClassName, columnConfig.className)}
-                style={mergeStyles(columnConfig.style, getWidthStyle(columnConfig.width))}
+                style={mergeStyles(columnConfig.style, { width: columnConfig.width })}
               >
                 {value != null ? value : <EmptyCell showSymbol={showEmptySymbol} />}
               </div>
@@ -117,11 +125,13 @@ let ScrollDivTable: ScrollDivTableProps = (props) => {
   }
 
   return (
-    <div className={cx(flex, column, props.wholeBorders ? styleWholeBorders : null, props.className)}>
-      <div className={cx(flex, column)}>
-        <div className={styleContentArea}>
-          {headElement}
-          <div className={styleBody}>{bodyElement}</div>
+    <div className={cx(flex, column, props.className)} data-component="scroll-div-table">
+      <div className={cx(flex, column, styleArea)} data-area="table-area">
+        <div ref={headerRef} className={cx(styleRow, styleHeaderBar)} style={mergeStyles({ width: allWidth, minWidth: "100%" }, rowPaddingStyle)}>
+          {headElements}
+        </div>
+        <div ref={scrollRef} className={cx(expand, styleContentArea)} data-area="wide-area" onScroll={(event) => handleScroll()}>
+          {bodyElements}
         </div>
       </div>
       {props.pageOptions != null ? renderPagination() : null}
@@ -134,10 +144,11 @@ export default ScrollDivTable;
 const styleCell = css`
   padding: 10px 8px;
   line-height: 20px;
-  flex-basis: 100px;
-  flex-shrink: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  display: inline-block;
+  width: 120px;
 `;
 
 const styleHeaderBar = css`
@@ -145,26 +156,24 @@ const styleHeaderBar = css`
   background-color: #f2f2f2;
   border: none;
   border-bottom: 1px solid #e5e5e5;
-`;
+  z-index: 1000;
 
-const styleBody = css`
-  color: rgba(0, 0, 0, 0.65);
+  position: absolute;
+  left: 0px;
+  top: 0;
+  width: auto;
 `;
 
 const styleRow = css`
   &:hover {
     background-color: #e6f7ff;
   }
+  color: rgba(0, 0, 0, 0.65);
 
   padding-left: 80px;
   border-bottom: 1px solid #e5e5e5;
 
-  width: 100%;
-`;
-
-let styleWholeBorders = css`
-  border-left: 1px solid #e5e5e5;
-  border-right: 1px solid #e5e5e5;
+  width: auto;
 `;
 
 const styleCursorPointer = css`
@@ -179,7 +188,15 @@ let stylePageArea = css`
   padding: 16px 8px;
 `;
 
-/** requires Chrome 46 */
 let styleContentArea = css`
-  min-width: max-content;
+  position: relative;
+  width: auto;
+  white-space: nowrap;
+  padding-top: 48px;
+`;
+
+let styleArea = css`
+  border: 1px solid #e5e5e5;
+  position: relative;
+  overflow: hidden;
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,10 +107,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.2.tgz#63985d3d8b02530e0869962f4da09142ee8e200e"
   integrity sha512-n/VQ4mbfr81aqkx/XmVicOLjviMuy02eenSdJY33SVA7S2J42EU0P1H0mOogfYedb3wXA0d/LVtBrgTSm04WEA==
 
-"@jimengio/doc-frame@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.npm.taobao.org/@jimengio/doc-frame/download/@jimengio/doc-frame-0.1.0.tgz#63d7d3f80b7ce0295c405ff9b7b29f9ee54417fe"
-  integrity sha1-Y9fT+At84ClcQF/5t7KfnuVEF/4=
+"@jimengio/doc-frame@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.npm.taobao.org/@jimengio/doc-frame/download/@jimengio/doc-frame-0.1.1.tgz#96f3444089be71de7e3f16dd184d2d71d9a2a88f"
+  integrity sha1-lvNEQIm+cd5+PxbdGE0tcdmiqI8=
 
 "@jimengio/jimo-icons@^0.1.19":
   version "0.1.19"


### PR DESCRIPTION
ScrollDivTable 布局的滚动区域问题. 目前简化了方案. 效果 http://fe.jimu.io/rough-table/#/wide

* 对于横向元素过多的, 不再使用 flexbox 布局, 而是固定每个 cell 或者 column 的宽度. 然后通过计算来辅助布局.
* 头部通过 `position: absolute` 配合 `left` 进行控制, 头部显示的位置跟滚动位置一致. 中间监听了 scroll 事件.
* 布局方式, 高版本浏览器可以用 `width: max-content` 从子节点撑开父节点, 需要 Chrome 46, 目标项目的 Chrome 44 不支持改属性, 只能采用手动计算的方式.

目前 demo 当中运行效果基本良好. 不过手动计算布局容易在边际情况出现问题, 后续要再想办法改进.
