### PR TITLE
refine body scrolling area; alpha release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/rough-table",
-  "version": "0.1.10-a2",
+  "version": "0.1.10-a3",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/scroll-div-table.tsx
+++ b/src/scroll-div-table.tsx
@@ -45,7 +45,7 @@ let ScrollDivTable: ScrollDivTableProps = (props) => {
 
   let handleScroll = () => {
     let leftOffset = scrollRef.current.scrollLeft;
-    headerRef.current.style.left = `${-leftOffset}px`;
+    headerRef.current.scrollLeft = leftOffset;
   };
 
   /** Effects */
@@ -127,8 +127,10 @@ let ScrollDivTable: ScrollDivTableProps = (props) => {
   return (
     <div className={cx(flex, column, props.className)} data-component="scroll-div-table">
       <div className={cx(flex, column, styleArea)} data-area="table-area">
-        <div ref={headerRef} className={cx(styleRow, styleHeaderBar)} style={mergeStyles({ width: allWidth, minWidth: "100%" }, rowPaddingStyle)}>
-          {headElements}
+        <div ref={headerRef} className={cx(styleHeaderBar)}>
+          <div className={styleRow} style={mergeStyles({ width: allWidth, minWidth: "100%" }, rowPaddingStyle)}>
+            {headElements}
+          </div>
         </div>
         <div ref={scrollRef} className={cx(expand, styleContentArea)} data-area="wide-area" onScroll={(event) => handleScroll()}>
           {bodyElements}
@@ -157,11 +159,7 @@ const styleHeaderBar = css`
   border: none;
   border-bottom: 1px solid #e5e5e5;
   z-index: 1000;
-
-  position: absolute;
-  left: 0px;
-  top: 0;
-  width: auto;
+  overflow: hidden;
 `;
 
 const styleRow = css`
@@ -192,7 +190,6 @@ let styleContentArea = css`
   position: relative;
   width: auto;
   white-space: nowrap;
-  padding-top: 48px;
 `;
 
 let styleArea = css`


### PR DESCRIPTION
修复了滚动条位置奇怪的问题.

另外有一些已知问题,

* 在 header 位置滚动, 不能触发 body 的滚动, 也就整体没有进行滚动.
* 滚动区域放大的时候, 显示不大美观.
