### PR TITLE
refine scroll area when table height not enough; alpha release

### DIFF
--- a/example/pages/pages/wide.tsx
+++ b/example/pages/pages/wide.tsx
@@ -3,7 +3,7 @@ import { css, cx } from "emotion";
 
 import ScrollDivTable from "../../../src/scroll-div-table";
 import { IRoughTableColumn } from "../../../src/rough-div-table";
-import { fullHeight } from "@jimengio/shared-utils";
+import { fullHeight, flex, column } from "@jimengio/shared-utils";
 
 let countMany = Array.from({ length: 100 }, (_, n) => n);
 
@@ -52,7 +52,15 @@ let columns: IRoughTableColumn<IData>[] = countMany.map((n) => {
 let PageWide: FC<{}> = (props) => {
   return (
     <div className={styleContainer}>
-      <ScrollDivTable data={data} columns={columns} rowPadding={60} pageOptions={{ current: 1, total: 100, pageSize: 10, onChange: (x) => {} }} />
+      <div className={cx(column, styleTallArea)}>
+        <ScrollDivTable
+          className={flex}
+          data={data}
+          columns={columns}
+          rowPadding={60}
+          pageOptions={{ current: 1, total: 100, pageSize: 10, onChange: (x) => {} }}
+        />
+      </div>
 
       <div>body 部分上下左右滚动(目前头部也发生滚动)</div>
       <div className={styleRestricted}>
@@ -68,4 +76,8 @@ let styleContainer = null;
 
 let styleRestricted = css`
   height: 400px;
+`;
+
+let styleTallArea = css`
+  height: 600px;
 `;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/rough-table",
-  "version": "0.1.10-a3",
+  "version": "0.1.10-a4",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/scroll-div-table.tsx
+++ b/src/scroll-div-table.tsx
@@ -126,14 +126,16 @@ let ScrollDivTable: ScrollDivTableProps = (props) => {
 
   return (
     <div className={cx(flex, column, props.className)} data-component="scroll-div-table">
-      <div className={cx(flex, column, styleArea)} data-area="table-area">
-        <div ref={headerRef} className={cx(styleHeaderBar)}>
-          <div className={styleRow} style={mergeStyles({ width: allWidth, minWidth: "100%" }, rowPaddingStyle)}>
-            {headElements}
+      <div className={cx(expand, column)}>
+        <div className={cx(flex, column, styleArea)} data-area="table-area">
+          <div ref={headerRef} className={cx(styleHeaderBar)}>
+            <div className={styleRow} style={mergeStyles({ width: allWidth, minWidth: "100%" }, rowPaddingStyle)}>
+              {headElements}
+            </div>
           </div>
-        </div>
-        <div ref={scrollRef} className={cx(expand, styleContentArea)} data-area="wide-area" onScroll={(event) => handleScroll()}>
-          {bodyElements}
+          <div ref={scrollRef} className={cx(expand, styleContentArea)} data-area="wide-area" onScroll={(event) => handleScroll()}>
+            {bodyElements}
+          </div>
         </div>
       </div>
       {props.pageOptions != null ? renderPagination() : null}
@@ -157,7 +159,6 @@ const styleHeaderBar = css`
   font-weight: bold;
   background-color: #f2f2f2;
   border: none;
-  border-bottom: 1px solid #e5e5e5;
   z-index: 1000;
   overflow: hidden;
 `;
@@ -190,10 +191,14 @@ let styleContentArea = css`
   position: relative;
   width: auto;
   white-space: nowrap;
+  border: 1px solid #e5e5e5;
+  border-width: 0px 1px 1px 1px;
+
+  /* works in Chrome 46+ */
+  max-height: max-content;
 `;
 
 let styleArea = css`
-  border: 1px solid #e5e5e5;
   position: relative;
   overflow: hidden;
 `;


### PR DESCRIPTION
为了达成下图这样的布局. 此前的版本滚动条位置往下偏了.

![image](https://user-images.githubusercontent.com/25790987/62455347-b7599180-b7a8-11e9-83bd-eb52f86fad23.png)

当前的代码对 Chrome 46+ 有效. Chrome 44 依然没有找到方案.
