### PR TITLE
disable hover color at table header; alpha release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/rough-table",
-  "version": "0.2.5",
+  "version": "0.2.6-a1",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/rough-div-table.tsx
+++ b/src/rough-div-table.tsx
@@ -150,6 +150,10 @@ const styleHeaderBar = css`
   background-color: #f2f2f2;
   border: none;
   border-bottom: 1px solid #e5e5e5;
+
+  &:hover {
+    background-color: #f2f2f2;
+  }
 `;
 
 const styleBody = css`
@@ -158,14 +162,14 @@ const styleBody = css`
 `;
 
 const styleRow = css`
-  &:hover {
-    background-color: #e6f7ff;
-  }
-
   padding-left: 80px;
   border-bottom: 1px solid #e5e5e5;
 
   width: 100%;
+
+  &:hover {
+    background-color: #e6f7ff;
+  }
 `;
 
 let styleWholeBorders = css`


### PR DESCRIPTION
Table header should not have hover color. Previews http://fe.jimu.io/rough-table/#/basic .
