### PR TITLE
fix: align header columns to body columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/rough-table",
-  "version": "0.2.18",
+  "version": "0.2.19-a1",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/rough-table",
-  "version": "0.2.19-a2",
+  "version": "0.2.19-a3",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/rough-table",
-  "version": "0.2.19-a1",
+  "version": "0.2.19-a2",
   "description": "",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/rough-div-table.tsx
+++ b/src/rough-div-table.tsx
@@ -79,6 +79,7 @@ type RoughDivTableProps<T = any> = FC<{
 let RoughDivTable: RoughDivTableProps = (props) => {
   let scrollRef = useRef<HTMLDivElement>();
   let headerRef = useRef<HTMLDivElement>();
+  let refHeadScroll = useRef<HTMLDivElement>();
 
   let [rowMinWidth, setRowMinWidth] = useState(0);
 
@@ -116,6 +117,12 @@ let RoughDivTable: RoughDivTableProps = (props) => {
       };
     }
   }, []);
+
+  useEffect(() => {
+    let scrollbarWidth = scrollRef.current.offsetWidth - scrollRef.current.clientWidth;
+    // align widths of header columns and body columns by fixed scrollbar area
+    refHeadScroll.current.style.width = `${scrollbarWidth}px`;
+  });
 
   /** Renderers */
 
@@ -161,6 +168,7 @@ let RoughDivTable: RoughDivTableProps = (props) => {
           </div>
         );
       })}
+      <div className={styleFakeScroll} ref={refHeadScroll}></div>
     </div>
   );
 
@@ -334,4 +342,8 @@ let styleCover = css`
 
 let styleLoadingEmpty = css`
   min-height: 80px;
+`;
+
+let styleFakeScroll = css`
+  width: 0px;
 `;

--- a/src/rough-div-table.tsx
+++ b/src/rough-div-table.tsx
@@ -123,7 +123,7 @@ let RoughDivTable: RoughDivTableProps = (props) => {
   useLayoutEffect(() => {
     let scrollbarWidth = scrollRef.current.offsetWidth - scrollRef.current.clientWidth;
     // change size as fast as possible, in case of shaking
-    headerRef.current.style.paddingRight = `${(props.rowPadding || 0) + scrollbarWidth}px`;
+    headerRef.current.style.paddingRight = `${(props.rowPadding || configuredProps.rowPadding) + scrollbarWidth}px`;
     if (scrollbarWidth !== scrollSize) {
       setScrollSize(scrollbarWidth);
     }


### PR DESCRIPTION
在顶部插入一个透明的区域, 跟 body 当中的 scrollbar 做对应, 这样其他的 column 宽度能对应上, 不出现偏差的几个像素.

Demo http://fe.jimu.io/rough-table/#/tall

![image](https://user-images.githubusercontent.com/25790987/78227088-50d76f80-74ff-11ea-83c7-ea0e820182e1.png)
