### PR TITLE
add renderType and renderOptions for dynamic customizing

### DIFF
--- a/example/controller/generated-router.ts
+++ b/example/controller/generated-router.ts
@@ -105,6 +105,12 @@ export let genRouter = {
     path: () => `/custom-theme`,
     go: () => switchPath(`/custom-theme`),
   },
+  registeredRenderer: {
+    name: "registered-renderer",
+    raw: "registered-renderer",
+    path: () => `/registered-renderer`,
+    go: () => switchPath(`/registered-renderer`),
+  },
   $: {
     name: "home",
     raw: "",
@@ -133,6 +139,7 @@ export interface GenRouterTypeTree {
     | GenRouterTypeTree["configure"]
     | GenRouterTypeTree["emptyPlaceholder"]
     | GenRouterTypeTree["customTheme"]
+    | GenRouterTypeTree["registeredRenderer"]
     | GenRouterTypeTree["$"];
   basic: {
     name: "basic";
@@ -220,6 +227,12 @@ export interface GenRouterTypeTree {
   };
   customTheme: {
     name: "custom-theme";
+    params: {};
+    query: {};
+    next: null;
+  };
+  registeredRenderer: {
+    name: "registered-renderer";
     params: {};
     query: {};
     next: null;

--- a/example/models/router-rules.ts
+++ b/example/models/router-rules.ts
@@ -16,5 +16,6 @@ export const routerRules: IRouteRule[] = [
   { path: "configure" },
   { path: "empty-placeholder" },
   { path: "custom-theme" },
+  { path: "registered-renderer" },
   { path: "", name: "home" },
 ];

--- a/example/pages/container.tsx
+++ b/example/pages/container.tsx
@@ -22,6 +22,7 @@ import DemoRowResizing from "./demo/row-resizing";
 import DemoConfigure from "./demo/configure";
 import DemoEmptyPlaceholder from "./demo/empty-placeholder";
 import CustomThemePage from "./custom-theme";
+import DemoRegisteredRenderer from "./demo/registered-renderer";
 
 const renderBody = (routerTree: GenRouterTypeMain) => {
   switch (routerTree?.name) {
@@ -53,6 +54,8 @@ const renderBody = (routerTree: GenRouterTypeMain) => {
       return <DemoEmptyPlaceholder />;
     case "custom-theme":
       return <CustomThemePage />;
+    case "registered-renderer":
+      return <DemoRegisteredRenderer />;
     case "home":
       return <HashRedirect to={genRouter.basic.path()} noDelay />;
   }
@@ -129,6 +132,11 @@ let entries: ISidebarEntry[] = [
     title: "Custom Theme",
     cnTitle: "主题样式",
     path: genRouter.customTheme.name,
+  },
+  {
+    title: "Register Renderer",
+    cnTitle: "注册渲染器",
+    path: genRouter.registeredRenderer.name,
   },
 ];
 

--- a/example/pages/demo/registered-renderer.tsx
+++ b/example/pages/demo/registered-renderer.tsx
@@ -1,0 +1,78 @@
+import React, { FC, useState, useRef, useEffect } from "react";
+import { css } from "emotion";
+
+import RoughDivTable, { IRoughTableColumn } from "../../../src/rough-div-table";
+import { DocDemo, DocSnippet, DocBlock } from "@jimengio/doc-frame";
+import { Space } from "@jimengio/flex-styles";
+import { registerRoughTableRenderer } from "../../../src/registered-renderer";
+
+let code = `
+let columns: IRoughTableColumn<IData>[] = [
+  { title: "物料编号", dataIndex: "code" },
+  { title: "名称", dataIndex: "name" },
+  { title: "型号", dataIndex: "model", render: (item: IData["model"], record: IData) => item },
+  { title: "操作", dataIndex: "model", width: 80, render: (item: any, record: IData) => <ActionLinks actions={actions} spaced /> },
+];
+
+<RoughDivTable data={data} columns={columns} />
+`;
+
+registerRoughTableRenderer("colored", (text, options) => {
+  // TODO, check data from options
+  let color = options.color || "red";
+
+  return (
+    <span className={styleColored} style={{ color: color }}>
+      {text}
+    </span>
+  );
+});
+
+interface IData {
+  code: string;
+  name: any;
+  model: string;
+  source: string;
+  type: string;
+}
+
+let data: IData[] = [
+  { code: "001", name: "螺丝", model: "DDR6 DDR7 DDR8 DDR9 DDR10 DDR11 DDR12 DDR13 DDR14", source: "外购", type: "产品" },
+  { code: "003", name: "扳手", model: "DDR6", source: "外购", type: "产品" },
+  { code: "004", name: "堵头", model: "33-36", source: "外购", type: "产品" },
+  { code: "044", name: "软管", model: "HO", source: "外购", type: "产品" },
+  { code: "045", name: 0, model: "HO", source: "外购", type: "产品" },
+];
+
+let columns: IRoughTableColumn<IData>[] = [
+  { title: "物料编号", dataIndex: "code" },
+  { title: "名称(colored...)", dataIndex: "name", renderType: "colored", renderOptions: { color: "blue" } },
+  { title: "名称(colored...)", dataIndex: "source", renderType: "colored", renderOptions: { color: "green" } },
+  { title: "型号", dataIndex: "model", render: (item: IData["model"], record: IData) => item },
+];
+
+let DemoRegisteredRenderer: FC<{}> = (props) => {
+  return (
+    <div className={styleContainer}>
+      <DocDemo title="A very simple table" link="https://github.com/jimengio/rough-table/blob/master/example/pages/demo/basic.tsx">
+        <DocBlock content={contentBasic} />
+        <DocSnippet code={code} />
+        <RoughDivTable data={data} columns={columns} />
+      </DocDemo>
+    </div>
+  );
+};
+
+export default DemoRegisteredRenderer;
+
+let styleContainer = null;
+
+let emptyContent = `无数据时显示.`;
+
+let contentBasic = `显示一个简单的表格`;
+
+let styleColored = css`
+  color: blue;
+  font-weight: bold;
+  font-size: 16px;
+`;

--- a/example/pages/demo/registered-renderer.tsx
+++ b/example/pages/demo/registered-renderer.tsx
@@ -7,14 +7,26 @@ import { Space } from "@jimengio/flex-styles";
 import { registerRoughTableRenderer } from "../../../src/registered-renderer";
 
 let code = `
+// 项目全局定义
+registerRoughTableRenderer("colored", (text, options) => {
+  // TODO, check data from options
+  let color = options.color || "red";
+
+  return (
+    <span className={styleColored} style={{ color: color }}>
+      {text}
+    </span>
+  );
+});
+
+// 使用
 let columns: IRoughTableColumn<IData>[] = [
   { title: "物料编号", dataIndex: "code" },
-  { title: "名称", dataIndex: "name" },
+  { title: "名称(colored...)", dataIndex: "name", renderType: "colored", renderOptions: { color: "blue" } },
+  { title: "名称(colored...)", dataIndex: "source", renderType: "colored", renderOptions: { color: "green" } },
   { title: "型号", dataIndex: "model", render: (item: IData["model"], record: IData) => item },
-  { title: "操作", dataIndex: "model", width: 80, render: (item: any, record: IData) => <ActionLinks actions={actions} spaced /> },
 ];
 
-<RoughDivTable data={data} columns={columns} />
 `;
 
 registerRoughTableRenderer("colored", (text, options) => {
@@ -47,7 +59,7 @@ let data: IData[] = [
 let columns: IRoughTableColumn<IData>[] = [
   { title: "物料编号", dataIndex: "code" },
   { title: "名称(colored...)", dataIndex: "name", renderType: "colored", renderOptions: { color: "blue" } },
-  { title: "名称(colored...)", dataIndex: "source", renderType: "colored", renderOptions: { color: "green" } },
+  { title: "来源(colored...)", dataIndex: "source", renderType: "colored", renderOptions: { color: "green" } },
   { title: "型号", dataIndex: "model", render: (item: IData["model"], record: IData) => item },
 ];
 
@@ -67,9 +79,7 @@ export default DemoRegisteredRenderer;
 
 let styleContainer = null;
 
-let emptyContent = `无数据时显示.`;
-
-let contentBasic = `显示一个简单的表格`;
+let contentBasic = `一个注册渲染器的方案. 全局注册渲染函数以后, 表格可以使用 \`renderType\` 属性指定使用该渲染器渲染. 可以减少一部分业务的重复代码.`;
 
 let styleColored = css`
   color: blue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export { default as ActionLinks, IActionLinkItem } from "./action-links";
 export { default as EmptyPlaceholder } from "./empty-placeholder";
 
 export { attachRoughTableThemeVariables } from "./theme";
+export { registerRoughTableRenderer } from "./registered-renderer";

--- a/src/registered-renderer.tsx
+++ b/src/registered-renderer.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from "react";
+import { isFunction } from "util";
+
+type FuncCellRenderer = (value: any, options: any) => ReactNode;
+
+let cellRenderers: { [k: string]: FuncCellRenderer } = {};
+
+export let registerRoughTableRenderer = (type: string, f: FuncCellRenderer) => {
+  if (cellRenderers[type] != null) {
+    console.warn("[RoughTable] overwriting render type", type, cellRenderers[type], f);
+  }
+  cellRenderers[type] = f;
+};
+
+export let getTableRenderer = (type: string): FuncCellRenderer => {
+  if (isFunction(cellRenderers[type])) {
+    return cellRenderers[type];
+  }
+  console.warn("[RoughTable] unknown render type", JSON.stringify(type), "among", Object.keys(cellRenderers), "resolved to", cellRenderers[type]);
+  return null;
+};


### PR DESCRIPTION
Previews http://fe.jimu.io/rough-table/#/registered-renderer 

新增属性,

* `renderType`, 指定使用渲染类型,
* `renderOptions`, 添加渲染参数,

新增 API:

* `registerRoughTableRenderer` 用于注册类型, 对应上边的 `renderType`.

新增功能类似"自定义渲染"的功能, 项目当中可以全局注册这样一个渲染方式, 然后 Table 定义时 columnConfig 上配置使用这个 type 以及带上 column 对应的 options, 完成自定义渲染.

典型的场景是时间和物料格式化, 目前做法是写 `render` 方法, 然后返回函数得到渲染结果. 用这个配置化的方案可以减少代码量.

缺陷, 这个方案是动态的, 没有 TypeScript 的类型支持, 所以需要补充一些动态的校验, 效果有比较有限.